### PR TITLE
Fix small Next.js x TypeScript nits

### DIFF
--- a/app/api/assistants/files/route.tsx
+++ b/app/api/assistants/files/route.tsx
@@ -1,7 +1,5 @@
-import OpenAI from "openai";
-import { assistantId } from "../../../assistant-config";
-
-const openai = new OpenAI();
+import { assistantId } from "@/app/assistant-config";
+import { openai } from "@/app/openai";
 
 // upload file to assistant's vector store
 export async function POST(request) {
@@ -41,7 +39,7 @@ export async function GET() {
       };
     })
   );
-  return new Response(JSON.stringify(filesArray));
+  return Response.json(filesArray);
 }
 
 // delete file from assistant's vector store

--- a/app/api/assistants/route.ts
+++ b/app/api/assistants/route.ts
@@ -1,5 +1,4 @@
-import OpenAI from "openai";
-const openai = new OpenAI();
+import { openai } from "@/app/openai";
 
 export const runtime = "nodejs";
 
@@ -35,5 +34,5 @@ export async function POST() {
       { type: "file_search" },
     ],
   });
-  return new Response(JSON.stringify({ assistantId: assistant.id }));
+  return Response.json({ assistantId: assistant.id });
 }

--- a/app/api/assistants/threads/[threadId]/actions/route.ts
+++ b/app/api/assistants/threads/[threadId]/actions/route.ts
@@ -1,14 +1,8 @@
-import OpenAI from "openai";
-const openai = new OpenAI();
-
-export const runtime = "nodejs";
+import { openai } from "@/app/openai";
 
 // Send a new message to a thread
-export async function POST(request, { params }) {
-  const body = await request.json();
-  const toolCallOutputs = body.toolCallOutputs;
-  const runId = body.runId;
-  const threadId = params.threadId;
+export async function POST(request, { params: { threadId } }) {
+  const { toolCallOutputs, runId } = await request.json();
 
   const stream = openai.beta.threads.runs.submitToolOutputsStream(
     threadId,

--- a/app/api/assistants/threads/[threadId]/messages/route.ts
+++ b/app/api/assistants/threads/[threadId]/messages/route.ts
@@ -1,14 +1,11 @@
-import OpenAI from "openai";
-import { assistantId } from "../../../../../assistant-config";
-const openai = new OpenAI();
+import { assistantId } from "@/app/assistant-config";
+import { openai } from "@/app/openai";
 
 export const runtime = "nodejs";
 
 // Send a new message to a thread
-export async function POST(request, { params }) {
-  const body = await request.json();
-  const content = body.content;
-  const threadId = params.threadId;
+export async function POST(request, { params: { threadId } }) {
+  const { content } = await request.json();
 
   await openai.beta.threads.messages.create(threadId, {
     role: "user",

--- a/app/api/assistants/threads/route.ts
+++ b/app/api/assistants/threads/route.ts
@@ -1,10 +1,9 @@
-import OpenAI from "openai";
-const openai = new OpenAI();
+import { openai } from "@/app/openai";
 
 export const runtime = "nodejs";
 
 // Create a new thread
 export async function POST() {
   const thread = await openai.beta.threads.create();
-  return new Response(JSON.stringify({ threadId: thread.id }));
+  return Response.json({ threadId: thread.id });
 }

--- a/app/openai.ts
+++ b/app/openai.ts
@@ -1,0 +1,3 @@
+import OpenAI from "openai";
+
+export const openai = new OpenAI();

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "@types/node": "20.12.7",
     "@types/react": "18.2.79",
     "typescript": "5.4.5"
+  },
+  "prettier": {
+    "singleQuote": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -20,15 +16,11 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
-  "include": [
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Only instantiate one OpenAI client and then import it everywhere  
- Use destructuring when possible in Route Handlers
- Use `Response.json()` instead `new Response(JSON.stringify())`
- Use TypeScript paths to simplify imports