### PR TITLE
Remove deprecated createAndStream method, use stream instead

### DIFF
--- a/app/api/assistants/threads/[threadId]/messages/route.ts
+++ b/app/api/assistants/threads/[threadId]/messages/route.ts
@@ -12,7 +12,7 @@ export async function POST(request, { params: { threadId } }) {
     content: content,
   });
 
-  const stream = openai.beta.threads.runs.createAndStream(threadId, {
+  const stream = openai.beta.threads.runs.stream(threadId, {
     assistant_id: assistantId,
   });
 


### PR DESCRIPTION
Fixes #8

This PR replaces the deprecated `createAndStream` method with the `stream` method. There is no difference in implementation between these two methods, which ensures a safe migration without affecting functionality.

`Runs.createAndStream`:
https://github.com/openai/openai-node/blob/dfae4097fae01f3ac49635e646876bd68d06cc3a/src/resources/beta/threads/runs/runs.ts#L126-L132

`Runs.stream`:
https://github.com/openai/openai-node/blob/dfae4097fae01f3ac49635e646876bd68d06cc3a/src/resources/beta/threads/runs/runs.ts#L190-L192
