### PR TITLE
Integrate CodeInterpreter Output: Fix File Download Link and Display Images in Chat

### DIFF
--- a/app/api/files/[fileId]/route.ts
+++ b/app/api/files/[fileId]/route.ts
@@ -2,7 +2,10 @@ import { openai } from "@/app/openai";
 
 // download file by file ID
 export async function GET(_request, { params: { fileId } }) {
-  const [file, fileContent] = await Promise.all([openai.files.retrieve(fileId), openai.files.content(fileId)]);
+  const [file, fileContent] = await Promise.all([
+    openai.files.retrieve(fileId),
+    openai.files.content(fileId),
+  ]);
   return new Response(fileContent.body, {
     headers: {
       "Content-Disposition": `attachment; filename="${file.filename}"`,

--- a/app/api/files/[fileId]/route.ts
+++ b/app/api/files/[fileId]/route.ts
@@ -1,0 +1,11 @@
+import { openai } from "@/app/openai";
+
+// download file by file ID
+export async function GET(_request, { params: { fileId } }) {
+  const [file, fileContent] = await Promise.all([openai.files.retrieve(fileId), openai.files.content(fileId)]);
+  return new Response(fileContent.body, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${file.filename}"`,
+    },
+  });
+}

--- a/app/components/chat.module.css
+++ b/app/components/chat.module.css
@@ -60,11 +60,13 @@
   align-self: flex-start;
   border-radius: 15px;
   max-width: 80%;
+  overflow-wrap: break-word;
 }
 
 .assistantMessage img {
   max-width: 100%;
-  padding: 8px 0px 8px 0px;
+  margin: 8px 0px 8px 0px;
+  border-radius: 8px;
 }
 
 .userMessage {

--- a/app/components/chat.module.css
+++ b/app/components/chat.module.css
@@ -87,3 +87,8 @@
   color: #b8b8b8;
   margin-right: 8px;
 }
+
+.chatImageContent {
+  max-width: 100%;
+  padding: 8px 0px 8px 0px;
+}

--- a/app/components/chat.module.css
+++ b/app/components/chat.module.css
@@ -62,6 +62,11 @@
   max-width: 80%;
 }
 
+.assistantMessage img {
+  max-width: 100%;
+  padding: 8px 0px 8px 0px;
+}
+
 .userMessage {
   align-self: flex-end;
   color: #fff;
@@ -86,9 +91,4 @@
 .codeMessage span {
   color: #b8b8b8;
   margin-right: 8px;
-}
-
-.chatImageContent {
-  max-width: 100%;
-  padding: 8px 0px 8px 0px;
 }

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, ReactNode, MouseEventHandler } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import styles from "./chat.module.css";
 import { AssistantStream } from "openai/lib/AssistantStream";
 import Markdown from "react-markdown";

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -27,6 +27,10 @@ const markdownOptions: Options = {
         return <a {...props} target="_blank" href={fileLink} />;
       }
       return <a {...props} target="_blank" />;
+    },
+
+    img(props) {
+      return <a href={props.src} target="_blank"><img {...props} className={styles.chatImageContent} /></a>;
     }
   },
 
@@ -169,6 +173,11 @@ const Chat = ({
     }
   };
 
+  // imageFileDone - show image in chat
+  const handleImageFileDone = (image) => {
+    appendToLastMessage(`\n![${image.file_id}](/api/files/${image.file_id})\n`);
+  }
+
   // toolCallCreated - log new tool call
   const toolCallCreated = (toolCall) => {
     if (toolCall.type != "code_interpreter") return;
@@ -208,6 +217,9 @@ const Chat = ({
     // messages
     stream.on("textCreated", handleTextCreated);
     stream.on("textDelta", handleTextDelta);
+
+    // image
+    stream.on("imageFileDone", handleImageFileDone);
 
     // code interpreter
     stream.on("toolCallCreated", toolCallCreated);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef, ReactNode, MouseEventHandler } from "react";
 import styles from "./chat.module.css";
 import { AssistantStream } from "openai/lib/AssistantStream";
-import Markdown, { Options, defaultUrlTransform } from "react-markdown";
+import Markdown from "react-markdown";
 // @ts-expect-error - no types for this yet
 import { AssistantStreamEvent } from "openai/resources/beta/assistants/assistants";
 import { RequiredActionFunctionToolCall } from "openai/resources/beta/threads/runs/runs";
@@ -17,35 +17,10 @@ const UserMessage = ({ text }: { text: string }) => {
   return <div className={styles.userMessage}>{text}</div>;
 };
 
-const markdownOptions: Options = {
-  components:{
-    a(props) {
-      const { href } = props;
-      if (href.indexOf('fileid:') === 0) {
-        const fileId = href.replace('fileid:', '');
-        const fileLink = `/api/files/${fileId}`;
-        return <a {...props} target="_blank" href={fileLink} />;
-      }
-      return <a {...props} target="_blank" />;
-    },
-
-    img(props) {
-      return <a href={props.src} target="_blank"><img {...props} className={styles.chatImageContent} /></a>;
-    }
-  },
-
-  urlTransform(url) {
-    if (url.indexOf('fileid:') === 0) {
-      return url;
-    }
-    return defaultUrlTransform(url);
-  }
-}
-
 const AssistantMessage = ({ text }: { text: string }) => {
   return (
     <div className={styles.assistantMessage}>
-      <Markdown {...markdownOptions}>{text}</Markdown>
+      <Markdown>{text}</Markdown>
     </div>
   );
 };
@@ -264,7 +239,7 @@ const Chat = ({
         if (annotation.type === 'file_path') {
           updatedLastMessage.text = updatedLastMessage.text.replaceAll(
             annotation.text,
-            `fileid:${annotation.file_path.file_id}`
+            `/api/files/${annotation.file_path.file_id}`
           );
         }
       })


### PR DESCRIPTION
Currently, the output handling from the CodeInterpreter has several issues:
- File download links do not function correctly (clicking them just reloads the page).
- An `undefined` text appears after the download link (refer to the image below).
- Images generated by the CodeInterpreter are not displayed in the chat interface.

![trailing undefined](https://github.com/openai/openai-assistants-quickstart/assets/40195276/349bca27-32e8-4c4e-833d-77c5449d643f)

This PR addresses these problems by:
- Ensuring that file download links function correctly by utilizing annotations and the File API.
- Removing the `undefined` text that appeared after download links.
- Enabling the display of images directly within the chat interface when they are generated.

Here are the fixes in action:
![fixed download link](https://github.com/openai/openai-assistants-quickstart/assets/40195276/fd82a3f3-ad39-4670-a865-1bea0cf09380)
![image in chat](https://github.com/openai/openai-assistants-quickstart/assets/40195276/90644fcd-c76e-4556-87f6-a27d9c3d0b28)

I hope you find these changes beneficial. I look forward to your feedback and hope for a merge.
